### PR TITLE
Added endpoint to mark a notification as read

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,5 @@ cython_debug/
 .mypy_cache/
 
 .vscode/
+.idea
+*.DS_Store

--- a/notify/data/notifications.py
+++ b/notify/data/notifications.py
@@ -36,3 +36,12 @@ def create(
     session.refresh(note)
 
     return note
+
+
+def mark_as_read(session: Session, notification_id: int) -> Notification:
+    note = session.query(Notification).where(Notification.id == notification_id).one()
+    note.read = True
+    session.add(note)
+    session.commit()
+    session.refresh(note)
+    return note

--- a/notify/handler/notify.py
+++ b/notify/handler/notify.py
@@ -38,3 +38,12 @@ class Notify:
                 raise HTTPException(400, "No user found for this notification")
 
         return note.to_JSON()
+
+    def mark_as_read(self, notification_id: int) -> NotificationResponse:
+        with self.db.get_session() as session:
+            try:
+                note = notifications.mark_as_read(session, notification_id)
+            except NoResultFound:
+                raise HTTPException(400, "No notification found")
+
+        return note.to_JSON()

--- a/notify/model/notification.py
+++ b/notify/model/notification.py
@@ -35,6 +35,7 @@ class Notification(CreationMetadataMixin, Base):
         ForeignKey("users.id"),
         index=True,
     )
+    read: Mapped[bool] = mapped_column(default=False)
 
     @classmethod
     def from_JSON(self, nr: "NotificationRequest") -> Self:
@@ -51,6 +52,7 @@ class NotificationRequest(BaseModel):
     payload: dict[str, Any]
     is_push_notification: bool | None = None
     user_id: int
+    read: bool | None = None
 
 
 class NotificationResponse(NotificationRequest):

--- a/notify/routes/notify.py
+++ b/notify/routes/notify.py
@@ -35,4 +35,11 @@ def notify(db: DB) -> APIRouter:
     ) -> NotificationResponse:
         return handler.post_notification(req)
 
+    @router.put('/notification/{notification_id}/read')
+    async def def_mark_as_read(
+            notification_id: int,
+            handler: Annotated[Notify, Depends(get_handler)]
+    ) -> NotificationResponse:
+        return handler.mark_as_read(notification_id)
+
     return router

--- a/notify/test/test_notify.py
+++ b/notify/test/test_notify.py
@@ -8,6 +8,27 @@ from notify.model import NotificationResponse
 
 
 @pytest.mark.parametrize(
+    "arg_notification_id, exp_status_code",
+    [
+        (1, 200)
+    ]
+)
+def test_mark_as_read(
+        session: Session,
+        client: TestClient,
+        testdata,
+        arg_notification_id,
+        exp_status_code,
+):
+    result = client.put(f'/notify/notification/{arg_notification_id}/read')
+    assert result.status_code == exp_status_code
+
+    if exp_status_code == 200:
+        resp = NotificationResponse.model_validate(result.json())
+        assert resp.read
+
+
+@pytest.mark.parametrize(
     "arg_user_id, exp_status_code, exp_notification_count",
     [
         (-1, 400, None),  # negative number should not be valid


### PR DESCRIPTION
Also, figured out why the tests were failing, I had to set a default value for the NotificationRequest, ie `read: bool | None = None`